### PR TITLE
fix plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,9 @@ authors:
 #    description: "This is the author box. Write a short description of the author here. You are currently previewing Affiliates theme demo, a Jekyll template compatible with Github pages."
 
 # Plugins
-plugins_dir:
-  - jekyll-paginate
-  - jekyll-archives
+plugins:
+- jekyll-paginate
+- jekyll-archives
 
 # Archives
 jekyll-archives:
@@ -46,5 +46,3 @@ jekyll-archives:
 # Other
 markdown: kramdown
 highlighter: rouge
-
-gems: [jekyll-paginate]


### PR DESCRIPTION
Plug-in `jekyll-paginate` is used but not declared correctly in the `_config.yml` file. When the plug-in is not installed, the site is built (broken) and only a warning is given:
```
Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `plugins: [jekyll-paginate]` in your configuration file.
```

This fix declares the plug-in in the correct way. As an effect, if the plug-in is missing, jekyll reports an error and does not build the website. See correct declaration https://github.com/jekyll/jekyll/issues/6195